### PR TITLE
Fix naming of finger joints to match VRM bone names

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,12 @@ Based on [VRM humanoid bone set](https://github.com/vrm-c/vrm-specification/blob
    │           └─ [left|right]UpperArm
    │              └─ [left|right]LowerArm
    │                 └─ [left|right]Hand
-   │                    └─ [left|right][Thumb|Index|Middle|Ring|Little]Metacarpal
-   │                       └─ [left|right][Thumb|Index|Middle|Ring|Little]Proximal
-   │                          └─ [left|right][Thumb|Index|Middle|Ring|Little]Distal
+   │                    ├─ [left|right]ThumbMetacarpal
+   │                    |  └─ [left|right]ThumbProximal
+   │                    |     └─ [left|right]ThumbDistal
+   │                    └─ [left|right][Index|Middle|Ring|Little]Proximal
+   │                       └─ [left|right][Index|Middle|Ring|Little]Intermediate
+   │                          └─ [left|right][Index|Middle|Ring|Little]Distal
    └─ [left|right]UpperLeg
       └─ [left|right]LowerLeg
          └─ [left|right]Foot

--- a/schema/animation.channel.target.EXT_skin_humanoid.schema.json
+++ b/schema/animation.channel.target.EXT_skin_humanoid.schema.json
@@ -6,8 +6,8 @@
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
     "properties": {
         "humanoidBoneName": {
-            "type": "string",
-        }
+            "type": "string"
+        },
         "extensions": { },
         "extras": { }
     },

--- a/schema/skin.EXT_skin_humanoid.schema.json
+++ b/schema/skin.EXT_skin_humanoid.schema.json
@@ -44,37 +44,37 @@
                 "leftThumbDistal": {
                     "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
-                "leftIndexMetacarpal": {
+                "leftIndexProximal": {
                     "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
-                "leftIndexProximal": {
+                "leftIndexIntermediate": {
                     "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "leftIndexDistal": {
                     "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
-                "leftMiddleMetacarpal": {
+                "leftMiddleProximal": {
                     "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
-                "leftMiddleProximal": {
+                "leftMiddleIntermediate": {
                     "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "leftMiddleDistal": {
                     "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
-                "leftRingMetacarpal": {
+                "leftRingProximal": {
                     "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
-                "leftRingProximal": {
+                "leftRingIntermediate": {
                     "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "leftRingDistal": {
                     "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
-                "leftLittleMetacarpal": {
+                "leftLittleProximal": {
                     "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
-                "leftLittleProximal": {
+                "leftLittleIntermediate": {
                     "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "leftLittleDistal": {
@@ -113,37 +113,37 @@
                 "rightThumbDistal": {
                     "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
-                "rightIndexMetacarpal": {
+                "rightIndexProximal": {
                     "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
-                "rightIndexProximal": {
+                "rightIndexIntermediate": {
                     "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "rightIndexDistal": {
                     "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
-                "rightMiddleMetacarpal": {
+                "rightMiddleProximal": {
                     "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
-                "rightMiddleProximal": {
+                "rightMiddleIntermediate": {
                     "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "rightMiddleDistal": {
                     "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
-                "rightRingMetacarpal": {
+                "rightRingProximal": {
                     "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
-                "rightRingProximal": {
+                "rightRingIntermediate": {
                     "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "rightRingDistal": {
                     "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
-                "rightLittleMetacarpal": {
+                "rightLittleProximal": {
                     "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
-                "rightLittleProximal": {
+                "rightLittleIntermediate": {
                     "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "rightLittleDistal": {

--- a/schema/skin.EXT_skin_humanoid.schema.json
+++ b/schema/skin.EXT_skin_humanoid.schema.json
@@ -9,160 +9,160 @@
             "type": "object",
             "properties": {
                 "hips": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "spine": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "upperChest": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "neck": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "head": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "leftShoulder": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "leftUpperArm": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "leftLowerArm": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "leftHand": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "leftThumbMetacarpal": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "leftThumbProximal": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "leftThumbDistal": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "leftIndexMetacarpal": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "leftIndexProximal": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "leftIndexDistal": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "leftMiddleMetacarpal": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "leftMiddleProximal": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "leftMiddleDistal": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "leftRingMetacarpal": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "leftRingProximal": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "leftRingDistal": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "leftLittleMetacarpal": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "leftLittleProximal": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "leftLittleDistal": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "leftUpperLeg": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "leftLowerLeg": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "leftFoot": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "leftToes": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "rightShoulder": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "rightUpperArm": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "rightLowerArm": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "rightHand": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "rightThumbMetacarpal": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "rightThumbProximal": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "rightThumbDistal": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "rightIndexMetacarpal": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "rightIndexProximal": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "rightIndexDistal": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "rightMiddleMetacarpal": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "rightMiddleProximal": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "rightMiddleDistal": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "rightRingMetacarpal": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "rightRingProximal": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "rightRingDistal": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "rightLittleMetacarpal": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "rightLittleProximal": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "rightLittleDistal": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "rightUpperLeg": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "rightLowerLeg": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "rightFoot": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
                 "rightToes": {
-                    "allOf": [ { "$ref": "glTFid.schema.json" } ],
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 }
             }
-        }
+        },
         "extensions": { },
         "extras": { }
     },


### PR DESCRIPTION
I noticed that the naming of the finger joints used Metacarpal, Proximal and Distal for _all_ fingers. In the VRM spec its only the thumbs that use these exact three. The other fingers have Proximal, Intermediate and Distal. This PR updates the naming so that it matches the VRM (1.0) naming.