### PR TITLE
Add left/rightEyes and jaw bones

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ Currently based on [VRM humanoid bone set](https://github.com/vrm-c/vrm-specific
    │     └─ upperChest
    │        ├─ neck
    │        │  └─ head
+   │        │     ├─ [left|right]Eye
+   │        │     └─ jaw
    │        └─ [left|right]Shoulder
    │           └─ [left|right]UpperArm
    │              └─ [left|right]LowerArm

--- a/schema/glTF.EXT_skeleton_humanoid.schema.json
+++ b/schema/glTF.EXT_skeleton_humanoid.schema.json
@@ -31,6 +31,15 @@
                 "head": {
                     "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },
+                "leftEye": {
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
+                },
+                "rightEye": {
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
+                },
+                "jaw": {
+                    "allOf": [ { "$ref": "glTFid.schema.json" } ]
+                },
                 "leftShoulder": {
                     "allOf": [ { "$ref": "glTFid.schema.json" } ]
                 },


### PR DESCRIPTION
Fixes #8 
Related #10

Currently default skeleton predefined in the extension is based on the one in VRM. And VRM skeleton is based on the Unity one.

I first thought that left/rightEyes and jaw bones might not be needed in major humanoid models because facial animation might be applied in different way (ex: morph) but there may be no reason to follow the existing major definition. Probably adding them doesn't hurt.